### PR TITLE
fix: reject invalid parameter counts during instantiation

### DIFF
--- a/examples/should_fail/param-channel-too-few.anvil
+++ b/examples/should_fail/param-channel-too-few.anvil
@@ -1,0 +1,20 @@
+chan ch<n : int> {
+    left req : (logic[n]@#2)
+}
+
+proc sub<n : int>(e : left ch<n>) {
+    loop {
+        let v = recv e.req >>
+        dprint "Value = %d" (v);
+        cycle 2
+    }
+}
+
+proc param_int_chan() {
+    chan e_le -- e_ri : ch<>;
+    spawn sub<4>(e_le);
+    loop {
+        send e_ri.req(4'd3) >>
+        cycle 2
+    }
+}

--- a/examples/should_fail/param-channel-too-many.anvil
+++ b/examples/should_fail/param-channel-too-many.anvil
@@ -1,0 +1,20 @@
+chan ch<n : int> {
+    left req : (logic[n]@#2)
+}
+
+proc sub<n : int>(e : left ch<n>) {
+    loop {
+        let v = recv e.req >>
+        dprint "Value = %d" (v);
+        cycle 2
+    }
+}
+
+proc param_int_chan() {
+    chan e_le -- e_ri : ch<4, 8>;
+    spawn sub<4>(e_le);
+    loop {
+        send e_ri.req(4'd3) >>
+        cycle 2
+    }
+}

--- a/examples/should_fail/param-type-too-few.anvil
+++ b/examples/should_fail/param-type-too-few.anvil
@@ -1,0 +1,18 @@
+struct foo<n : int> {
+    v : logic[n]
+}
+
+proc sub<n : int>() {
+    reg r : foo<>;
+    loop {
+        dprint "Value = %d" ((*r).v);
+        set r.v := (*r).v + 1
+    }
+}
+
+proc param_int_typedef() {
+    spawn sub<4>();
+    loop {
+        cycle 1
+    }
+}

--- a/examples/should_fail/param-type-too-many.anvil
+++ b/examples/should_fail/param-type-too-many.anvil
@@ -1,0 +1,18 @@
+struct foo<n : int> {
+    v : logic[n]
+}
+
+proc sub<n : int>() {
+    reg r : foo<n, 8>;
+    loop {
+        dprint "Value = %d" ((*r).v);
+        set r.v := (*r).v + 1
+    }
+}
+
+proc param_int_typedef() {
+    spawn sub<4>();
+    loop {
+        cycle 1
+    }
+}

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -71,7 +71,7 @@ let codegen_spawns printer (graphs : event_graph_collection) (g : proc_graph) =
       let endpoint_name_local = CodegenFormat.canonicalize_endpoint_name param_ident (List.hd g.threads |> fst) in
       let cc = MessageCollection.lookup_channel_class graphs.channel_classes endpoint_local.channel_class |> Option.get in
       let print_msg_con = fun (msg : message_def) ->
-        let msg = ParamConcretise.concretise_message cc.params endpoint_local.channel_params msg in
+        let msg = ParamConcretise.concretise_message endpoint_local.channel_class cc.params endpoint_local.channel_params msg in
         if CodegenPort.message_has_valid_port msg then
             gen_connect (Format.format_msg_valid_signal_name arg_endpoint.name msg.name)
               (Format.format_msg_valid_signal_name endpoint_name_local msg.name)
@@ -97,7 +97,7 @@ let codegen_spawns printer (graphs : event_graph_collection) (g : proc_graph) =
         end
       in 
       let print_msg_con_last = fun (msg : message_def) ->
-        let msg = ParamConcretise.concretise_message cc.params endpoint_local.channel_params msg in
+        let msg = ParamConcretise.concretise_message endpoint_local.channel_class cc.params endpoint_local.channel_params msg in
         if CodegenPort.message_has_valid_port msg then
             gen_connect_post (Format.format_msg_valid_signal_name arg_endpoint.name msg.name)
               (Format.format_msg_valid_signal_name endpoint_name_local msg.name)

--- a/lib/codegenPort.ml
+++ b/lib/codegenPort.ml
@@ -13,7 +13,7 @@ let message_has_data_port (msg : message_def) (idx : int) : bool = (List.nth msg
 let gather_ports_from_endpoint (channel_classes : channel_class_def list) (endpoint : endpoint_def) : t list =
   let cc = Option.get (MessageCollection.lookup_channel_class channel_classes endpoint.channel_class) in
   let gen_endpoint_ports = fun (msg : message_def) ->
-    let msg = ParamConcretise.concretise_message cc.params endpoint.channel_params msg in
+    let msg = ParamConcretise.concretise_message endpoint.channel_class cc.params endpoint.channel_params msg in
     let folder_inner = fun fmt msg_dir (n, port_list) (stype : sig_type_chan_local) ->
       if stype.dtype = Lang.unit_dtype then (n, port_list)
       else

--- a/lib/graphBuildDriver.ml
+++ b/lib/graphBuildDriver.ml
@@ -55,7 +55,7 @@ let build_proc (config : Config.compile_config) sched module_name param_values
     if param_values = [] then
       proc
     else
-      ParamConcretise.concretise_proc param_values proc
+      ParamConcretise.concretise_proc module_name param_values proc
   in
   let macro_defs_extended =
     if List.length param_values <> List.length proc.params then

--- a/lib/messageCollection.ml
+++ b/lib/messageCollection.ml
@@ -31,7 +31,7 @@ let lookup_message (mc : t) (msg_spec : message_specifier) (channel_classes : ch
     let* msg = List.find_opt (fun (m : message_def) -> m.name = msg_spec.msg) cc.messages in
     (* adjust the direction of the message to account for the direction of the endpoint *)
     let* msg = Some {msg with dir = get_message_direction msg.dir endpoint.dir} in
-    Some (ParamConcretise.concretise_message cc.params endpoint.channel_params msg)
+    Some (ParamConcretise.concretise_message endpoint.channel_class cc.params endpoint.channel_params msg)
   )
 
 let message_sync_mode_allowed = function
@@ -88,7 +88,7 @@ let create (channels : channel_def ast_node list)
       [(left_endpoint, span); (right_endpoint, span)]
     else 
       let n' = Option.get chan.n_instances in
-      let n = ParamConcretise.concretise_array_dimm proc_params param_values n' in
+      let n = ParamConcretise.concretise_array_dimm chan.channel_class proc_params param_values n' in
       let left_nm_list = create_endpoint_array_string n [chan.endpoint_left] in
       let right_nm_list = create_endpoint_array_string n [chan.endpoint_right] in
       assert (List.length left_nm_list = List.length right_nm_list);
@@ -113,7 +113,7 @@ let create (channels : channel_def ast_node list)
           (* these should have been checked earlier *)
           assert ((message_sync_mode_allowed msg.send_sync) && (message_sync_mode_allowed msg.recv_sync));
           let msg_dir = get_message_direction msg.dir endpoint.dir in
-          (endpoint, ParamConcretise.concretise_message cc.params endpoint.channel_params msg, msg_dir)
+          (endpoint, ParamConcretise.concretise_message endpoint.channel_class cc.params endpoint.channel_params msg, msg_dir)
         in List.map msg_map cc.messages
     | None ->
         raise (Except.TypeError [
@@ -130,7 +130,7 @@ let create (channels : channel_def ast_node list)
         [({ep with foreign = get_foreign ep.name}, span)]
     | Some num ->
         (* let num_instances = in *)
-        let num_instances = ParamConcretise.concretise_array_dimm proc_params param_values num in
+        let num_instances = ParamConcretise.concretise_array_dimm ep.name proc_params param_values num in
         let size_instances = get_size_instances num_instances in
         if size_instances <= 0 then
           raise (Except.TypeError [

--- a/lib/paramConcretise.ml
+++ b/lib/paramConcretise.ml
@@ -67,6 +67,12 @@ and concretise_dtype_params int_env type_env (dtype : data_type) : data_type =
   | _ -> dtype
 
 let build_param_envs param_values params =
+  let expected = List.length params
+  and actual = List.length param_values in
+  if expected <> actual then
+    raise (Except.TypeError [
+      Text (Printf.sprintf "Expected %d parameters but got %d" expected actual)
+    ]);
   let int_env = create_env ()
   and type_env = create_env () in
   let vals_s = List.to_seq param_values

--- a/lib/paramConcretise.ml
+++ b/lib/paramConcretise.ml
@@ -66,13 +66,17 @@ and concretise_dtype_params int_env type_env (dtype : data_type) : data_type =
     `Tuple elems_dtypes'
   | _ -> dtype
 
-let build_param_envs param_values params =
+let build_param_envs context param_values params =
   let expected = List.length params
   and actual = List.length param_values in
   if expected <> actual then
+    let parameter_word = if expected = 1 then "parameter" else "parameters" in
     raise (Except.TypeError [
-      Text (Printf.sprintf "Expected %d parameters but got %d" expected actual)
-    ]);
+      Text (Printf.sprintf
+        "Expected %d %s but got %d in %s"
+        expected parameter_word actual context)
+    ])
+  else ();
   let int_env = create_env ()
   and type_env = create_env () in
   let vals_s = List.to_seq param_values
@@ -89,11 +93,11 @@ let build_param_envs param_values params =
       );
   (int_env, type_env)
 
-let concretise_proc param_values proc =
+let concretise_proc context param_values proc =
   if proc.params = [] then
     proc
   else (
-    let (int_param_env, type_param_env) = build_param_envs param_values proc.params in
+    let (int_param_env, type_param_env) = build_param_envs context param_values proc.params in
     let args = List.map
       (fun ({d = a; span} : endpoint_def ast_node) ->
         let params = concretise_params int_param_env type_param_env a.channel_params in
@@ -122,12 +126,12 @@ let concretise_proc param_values proc =
     )
   )
 
-let concretise_dtype params param_values =
-  let (int_param_env, type_param_env) = build_param_envs param_values params in
+let concretise_dtype context params param_values =
+  let (int_param_env, type_param_env) = build_param_envs context param_values params in
   concretise_dtype_params int_param_env type_param_env
 
-let concretise_message params param_values (msg : Lang.message_def) =
-  let (int_param_env, type_param_env) = build_param_envs param_values params in
+let concretise_message context params param_values (msg : Lang.message_def) =
+  let (int_param_env, type_param_env) = build_param_envs context param_values params in
   let sig_types = List.map
     (fun (stype : Lang.sig_type_chan_local) ->
       {stype with dtype = concretise_dtype_params int_param_env type_param_env stype.dtype}
@@ -137,8 +141,8 @@ let concretise_message params param_values (msg : Lang.message_def) =
   {msg with sig_types}
 
 
-let concretise_array_dimm params param_values (dimm : Lang.array_dimensions) : array_dimm_concrete =
-  let (int_param_env, _) = build_param_envs param_values params in
+let concretise_array_dimm context params param_values (dimm : Lang.array_dimensions) : array_dimm_concrete =
+  let (int_param_env, _) = build_param_envs context param_values params in
   let mappings = ParamEnv.map_list (fun k v ->
     Printf.sprintf "%s : %d\n" k v
   ) int_param_env in

--- a/lib/paramConcretise.mli
+++ b/lib/paramConcretise.mli
@@ -1,11 +1,11 @@
 (** Concretise the parameters in a process. This includes concretising the parameters
     used for spawning new processes, defining data types, or defining channel classes. *)
-val concretise_proc : Lang.param_value list -> Lang.proc_def -> Lang.proc_def
+val concretise_proc : string -> Lang.param_value list -> Lang.proc_def -> Lang.proc_def
 
 (** Concretise data type body. *)
-val concretise_dtype : Lang.param list -> Lang.param_value list -> Lang.data_type -> Lang.data_type
+val concretise_dtype : string -> Lang.param list -> Lang.param_value list -> Lang.data_type -> Lang.data_type
 
 (** Concretise message. *)
-val concretise_message : Lang.param list -> Lang.param_value list -> Lang.message_def -> Lang.message_def
+val concretise_message : string -> Lang.param list -> Lang.param_value list -> Lang.message_def -> Lang.message_def
 
-val concretise_array_dimm : Lang.param list -> Lang.param_value list -> Lang.array_dimensions -> Lang.array_dimm_concrete
+val concretise_array_dimm : string -> Lang.param list -> Lang.param_value list -> Lang.array_dimensions -> Lang.array_dimm_concrete

--- a/lib/typedefMap.ml
+++ b/lib/typedefMap.ml
@@ -11,7 +11,7 @@ let of_list typedef_list =
 let data_type_name_resolve (type_defs : t) (dtype : data_type) : data_type option =
   match dtype with
   | `Named (type_name, params) -> Utils.StringMap.find_opt type_name type_defs |> Option.map (fun (x : type_def) ->
-      ParamConcretise.concretise_dtype x.params params x.body)
+      ParamConcretise.concretise_dtype type_name x.params params x.body)
   | _ -> Some dtype
 
 let rec data_type_size (type_defs : t) (macro_defs : macro_def list) (dtype : data_type) : int =
@@ -34,7 +34,7 @@ let rec data_type_size (type_defs : t) (macro_defs : macro_def list) (dtype : da
       | Some type_def -> type_def
       | None -> failwith("Unknown Datatype: "^type_name)
       in
-      ParamConcretise.concretise_dtype type_def.params params type_def.body |> data_type_size type_defs macro_defs
+      ParamConcretise.concretise_dtype type_name type_def.params params type_def.body |> data_type_size type_defs macro_defs
   | `Variant (dt,vlist) as var ->
       let mx_data_size = List.fold_left (fun m (_,dt,_) -> max m (
         let inner_dtype_op = dt in


### PR DESCRIPTION
## Summary

Adds parameter arity validation during parameter concretisation.

Previously, parameter values and declarations were combined using `Seq.zip` without checking their lengths. This could cause extra parameters to be silently ignored, while missing parameters could result in failures later during concretisation instead of a clear type error.

## Changes

- Validate that the number of supplied parameters matches the number expected before building the parameter environments.
- Report a `TypeError` when the parameter count does not match.
- Add regression tests for too few and too many parameters in parameterised type and channel instantiations.

Related to #4.